### PR TITLE
Update hero section video to use new h264 asset

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import posterImage from "@/assets/camisa_preta.jpg";
-import heroVideo from "@/assets/video_camisa_preta.mp4";
+import heroVideo from "@/assets/video_camisa_preta.h264?url";
 
 const HeroSection = () => {
   return (
@@ -118,7 +118,7 @@ const VideoShowcase = () => {
             aria-label="Video showcasing the capsule collection shirt"
             disablePictureInPicture
           >
-            <source src={heroVideo} type="video/mp4" />
+            <source src={heroVideo} type="video/h264" />
             Your browser does not support the video tag.
           </video>
         )}


### PR DESCRIPTION
## Summary
- update the hero section video source to reference the new `video_camisa_preta.h264` asset
- adjust the video MIME type to match the new format

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d016af68e0832da989a08d24a0f7cc