### PR TITLE
Add mobile menu toggle for header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,17 +1,17 @@
-import { useState } from "react";
+import { type MouseEvent, useState } from "react";
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const handleScrollToCollections = (e: any) => {
-    e.preventDefault();
+  const handleScrollToCollections = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
     const el = document.getElementById("collections");
     if (el) el.scrollIntoView({ behavior: "smooth" });
     setIsMenuOpen(false);
   };
 
-  const handleScrollToContact = (e: any) => {
-    e.preventDefault();
+  const handleScrollToContact = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
     const el = document.getElementById("contact");
     if (el) el.scrollIntoView({ behavior: "smooth" });
     setIsMenuOpen(false);
@@ -40,11 +40,42 @@ const Header = () => {
               Contact
             </a>
           </nav>
+
+          {/* Mobile Menu Button */}
+          <button
+            type="button"
+            className="md:hidden inline-flex items-center justify-center rounded-md border border-border px-3 py-2 text-sm font-medium tracking-wide transition-colors hover:bg-accent hover:text-accent-foreground"
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+            aria-expanded={isMenuOpen}
+            aria-controls="mobile-navigation"
+            aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+          >
+            <span className="sr-only">Toggle navigation</span>
+            <svg
+              className="h-5 w-5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              {isMenuOpen ? (
+                <path d="M6 18L18 6M6 6l12 12" />
+              ) : (
+                <>
+                  <path d="M4 6h16" />
+                  <path d="M4 12h16" />
+                  <path d="M4 18h16" />
+                </>
+              )}
+            </svg>
+          </button>
         </div>
 
         {/* Mobile Navigation */}
         {isMenuOpen && (
-          <nav className="md:hidden mt-6 pb-6 border-t border-border pt-6">
+          <nav id="mobile-navigation" className="md:hidden mt-6 pb-6 border-t border-border pt-6">
             <div className="flex flex-col space-y-4">
               <a href="#" className="text-base font-light tracking-wide hover:text-accent transition-colors">
                 News

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,14 @@ const Header = () => {
     setIsMenuOpen(false);
   };
 
+  const handleScrollToHero = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    const el = document.getElementById("hero");
+    if (el) el.scrollIntoView({ behavior: "smooth" });
+    setIsMenuOpen(false);
+  };
+
+
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-md border-b border-border">
       <div className="container mx-auto px-6 py-4">
@@ -77,7 +85,7 @@ const Header = () => {
         {isMenuOpen && (
           <nav id="mobile-navigation" className="md:hidden mt-6 pb-6 border-t border-border pt-6">
             <div className="flex flex-col space-y-4">
-              <a href="#" className="text-base font-light tracking-wide hover:text-accent transition-colors">
+              <a href="#" onClick={handleScrollToHero} className="text-base font-light tracking-wide hover:text-accent transition-colors">
                 News
               </a>
               <a href="#collections" onClick={handleScrollToCollections} className="text-base font-light tracking-wide hover:text-accent transition-colors">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -23,7 +23,7 @@ const HeroSection = () => {
   }, []);
 
   return (
-    <section className="min-h-screen flex items-center justify-center bg-background">
+    <section id="hero" className="min-h-screen flex items-center justify-center bg-background">
       <div className="container mx-auto px-6 py-20">
         <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
           {/* Texto */}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -6,18 +6,19 @@ const HeroSection = () => {
   const [failedAutoplay, setFailedAutoplay] = useState(false);
 
   useEffect(() => {
-    const v = videoRef.current;
-    if (!v) return;
+    const video = videoRef.current;
+    if (!video) return;
 
     // iOS/Safari: garanta inline + mudo antes do play
-    v.muted = true;
-    (v as any).defaultMuted = true;
-    v.playsInline = true;
-    v.setAttribute("webkit-playsinline", "true");
+    const enhancedVideo = video as HTMLVideoElement & { defaultMuted?: boolean };
+    enhancedVideo.muted = true;
+    enhancedVideo.defaultMuted = true;
+    enhancedVideo.playsInline = true;
+    enhancedVideo.setAttribute("webkit-playsinline", "true");
 
-    const p = v.play?.();
-    if (p && typeof p.catch === "function") {
-      p.catch(() => setFailedAutoplay(true)); // fallback se bloquear autoplay
+    const playPromise = enhancedVideo.play?.();
+    if (playPromise && typeof playPromise.catch === "function") {
+      playPromise.catch(() => setFailedAutoplay(true)); // fallback se bloquear autoplay
     }
   }, []);
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -97,5 +98,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add a hamburger toggle so the header navigation is accessible on mobile and typed the scroll handlers
- tighten TypeScript usage in shared components flagged by lint and adjust the hero video helper
- switch the Tailwind animate plugin to an ESM import to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d14ec4c498832d8ba767ff2fe9b613